### PR TITLE
WIP - Add basic color swatches directive

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -1,4 +1,27 @@
-﻿(function () {
+﻿
+/**
+@ngdoc directive
+@name umbraco.directives.directive:umbColorSwatches
+@restrict E
+@scope
+@description
+Use this directive to generate color swatches to pick from.
+<h3>Markup example</h3>
+<pre>
+    <umb-color-swatches
+        colors="colors"
+        selected-color="color"
+        size="s">
+    </umb-color-swatches>
+</pre>
+@param {array} colors (<code>attribute</code>): The array of colors.
+@param {string} colors (<code>attribute</code>): The array of colors.
+@param {string} selectedColor (<code>attribute</code>): The selected color.
+@param {string} size (<code>attribute</code>): The size (s, m).
+@param {function} onSelect (<code>expression</code>): Callback function when the item is selected.
+**/
+
+(function () {
     'use strict';
 
     function ColorSwatchesDirective() {
@@ -9,10 +32,7 @@
                 //scope.selectedColor({color: color });
                 scope.selectedColor = color;
 
-                console.log("selectedColor", selectedColor);
-
                 if (scope.onSelect) {
-                    console.log("onselect", color);
                     scope.onSelect(color);
                 }
             };
@@ -24,9 +44,10 @@
             transclude: true,
             templateUrl: 'views/components/umb-color-swatches.html',
             scope: {
-                colors: "=",
-                selectedColor: "&",
-                onSelect: '='
+                colors: '=?',
+                size: '@',
+                selectedColor: '=',
+                onSelect: '&'
             },
             link: link
         };

--- a/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
+++ b/src/Umbraco.Web.UI.Client/src/common/directives/components/umbcolorswatches.directive.js
@@ -1,0 +1,40 @@
+﻿(function () {
+    'use strict';
+
+    function ColorSwatchesDirective() {
+
+        function link(scope, el, attr, ctrl) {
+
+            scope.setColor = function (color) {
+                //scope.selectedColor({color: color });
+                scope.selectedColor = color;
+
+                console.log("selectedColor", selectedColor);
+
+                if (scope.onSelect) {
+                    console.log("onselect", color);
+                    scope.onSelect(color);
+                }
+            };
+        }
+
+        var directive = {
+            restrict: 'E',
+            replace: true,
+            transclude: true,
+            templateUrl: 'views/components/umb-color-swatches.html',
+            scope: {
+                colors: "=",
+                selectedColor: "&",
+                onSelect: '='
+            },
+            link: link
+        };
+
+        return directive;
+
+    }
+
+    angular.module('umbraco.directives').directive('umbColorSwatches', ColorSwatchesDirective);
+
+})();

--- a/src/Umbraco.Web.UI.Client/src/less/belle.less
+++ b/src/Umbraco.Web.UI.Client/src/less/belle.less
@@ -114,6 +114,7 @@
 @import "components/umb-grid.less";
 @import "components/umb-empty-state.less";
 @import "components/umb-property-editor.less";
+@import "components/umb-color-swatches.less";
 @import "components/umb-iconpicker.less";
 @import "components/umb-insert-code-box.less";
 @import "components/umb-packages.less";

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -1,0 +1,43 @@
+﻿.umb-color-swatches {
+
+    .color-box {
+        border: none;
+        color: white;
+        cursor: pointer;
+        padding: 5px;
+        text-align: center;
+        text-decoration: none;
+        display: inline-block;
+        margin: 5px;
+        border-radius: 3px;
+        width: 30px;
+        height: 30px;
+        transition: box-shadow .3s;
+
+        &:hover, &:focus {
+            box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+        }
+
+        .check_circle {
+            display: none;
+            width: 20px;
+            height: 20px;
+
+            .icon {
+                font-size: 14px;
+                display: inline-block;
+                width: 20px;
+                height: 20px;
+                border-radius: 50%;
+                background-color: rgba(0,0,0,.15);
+                float: right;
+            }
+        }
+
+        &.active {
+            .check_circle {
+                display: inline-block;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/umb-color-swatches.less
@@ -1,6 +1,6 @@
 ﻿.umb-color-swatches {
 
-    .color-box {
+    .umb-color-box {
         border: none;
         color: white;
         cursor: pointer;
@@ -20,23 +20,41 @@
 
         .check_circle {
             display: none;
+            visibility: hidden;
             width: 20px;
             height: 20px;
+            margin: 0 auto;
 
             .icon {
-                font-size: 14px;
-                display: inline-block;
-                width: 20px;
-                height: 20px;
+                font-size: 1em;
+                display: flex;
+                width: 100%;
+                height: 100%;
+                align-items: center;
+                justify-content: center;
                 border-radius: 50%;
                 background-color: rgba(0,0,0,.15);
-                float: right;
+                float: left;
             }
         }
 
         &.active {
             .check_circle {
-                display: inline-block;
+                display: flex;
+                visibility: visible;
+            }
+        }
+
+        &.umb-color-box--s {
+        }
+
+        &.umb-color-box--m {
+            width: 40px;
+            height: 40px;
+
+            .check_circle {
+                width: 25px;
+                height: 25px;
             }
         }
     }

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -33,9 +33,14 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
        { name: 'Indigo', value: 'color-indigo' }
    ];
 
+    $scope.setNewColor = function (color) {
+        $scope.color = color;
+        console.log(color);
+    };
+
    $scope.setColor = function (color) {   
        $scope.color = color;
-       console.log(color);    
+       //console.log(color);    
    };
 
    iconHelper.getIcons().then(function(icons) {

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -33,11 +33,6 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
        { name: 'Indigo', value: 'color-indigo' }
    ];
 
-    $scope.setNewColor = function (color) {
-        $scope.color = color;
-        console.log(color);
-    };
-
    $scope.setColor = function (color) {   
        $scope.color = color;
        //console.log(color);    

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -33,6 +33,11 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
        { name: 'Indigo', value: 'color-indigo' }
    ];
 
+    if (!$scope.color) {
+        // Set default selected color to black
+        $scope.color = $scope.colors[0].value;
+    }
+
    $scope.setColor = function (color) {   
        $scope.color = color;
        //console.log(color);    

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.controller.js
@@ -30,8 +30,8 @@ function IconPickerOverlay($scope, iconHelper, localizationService) {
        { name: 'Pink', value: 'color-pink' },
        { name: 'Purple', value: 'color-purple' },
        { name: 'Deep Purple', value: 'color-deep-purple' },
-       { name: 'Indigo', value: 'color-indigo'}
-   ]
+       { name: 'Indigo', value: 'color-indigo' }
+   ];
 
    $scope.setColor = function (color) {   
        $scope.color = color;

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -16,7 +16,7 @@
     </div>
 
     <div class="umb-control-group">
-        <umb-color-swatches colors="colors" on-select="setColor()"></umb-color-swatches>
+        <umb-color-swatches colors="colors" selected-color="color" size="m"></umb-color-swatches>
     </div>
 
     <div class="umb-control-group">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -14,6 +14,11 @@
                    no-dirty-check />
         </div>
     </div>
+
+    <div class="umb-control-group">
+        <umb-color-swatches colors="colors" on-select="setColor()"></umb-color-swatches>
+    </div>
+
     <div class="umb-control-group">
         <button ng-repeat="c in colors" class="button btn-{{c.value}}" ng-class="{ active: c.value === color }" title="{{c.name}}" ng-click="setColor(c.value)">
             <div class="check_circle" ng-class="{active:c.value === color}">

--- a/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
+++ b/src/Umbraco.Web.UI.Client/src/views/common/overlays/iconpicker/iconpicker.html
@@ -16,7 +16,7 @@
     </div>
 
     <div class="umb-control-group">
-        <umb-color-swatches colors="colors" selected-color="color" size="m"></umb-color-swatches>
+        <umb-color-swatches colors="colors" selected-color="color" size="s"></umb-color-swatches>
     </div>
 
     <div class="umb-control-group">

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,6 +1,6 @@
 ﻿<div class="umb-color-swatches">
 
-    <button class="color-box btn-{{color.value}}" ng-repeat="color in colors" title="{{color.name}}" ng-class="{active:color.value === selectedColor}" ng-click="setColor(color.value)">
+    <button class="umb-color-box umb-color-box--{{size}} btn-{{color.value}}" ng-repeat="color in colors" title="{{color.name}}" ng-class="{active:color.value === selectedColor}" ng-click="setColor(color.value)">
         <div class="check_circle">
             <i class="icon icon-check small"></i>
         </div>

--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-color-swatches.html
@@ -1,0 +1,10 @@
+﻿<div class="umb-color-swatches">
+
+    <button class="color-box btn-{{color.value}}" ng-repeat="color in colors" title="{{color.name}}" ng-class="{active:color.value === selectedColor}" ng-click="setColor(color.value)">
+        <div class="check_circle">
+            <i class="icon icon-check small"></i>
+        </div>
+    </button>
+
+    {{selectedColor}}
+</div>


### PR DESCRIPTION
This is a basic color swatches directive. It need a bit more work, but I think it would be useful to re-use this in the backoffice UI, e.g. for property editors, prevalue editors and in grid editor config settings/styles.